### PR TITLE
메인 페이지(로그인 전후 다르게)

### DIFF
--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -5,6 +5,7 @@ import SearchIcon from "@material-ui/icons/Search";
 
 import Text from "@Style/Text";
 import Button from "@Style/Button";
+import Avatar from "@Style/Avatar";
 import { media } from "@Style/util";
 
 interface IHeader {
@@ -133,13 +134,6 @@ const UserButton = styled(Button)`
 const LogoutWrapper = styled.div`
   display: flex;
   align-items: center;
-`;
-
-const Avatar = styled.img`
-  height: 30px;
-  width: 30px;
-  border-radius: 5px;
-  margin: 0 15px 0 10px;
 `;
 
 export default Header;

--- a/client/src/style/Avatar.tsx
+++ b/client/src/style/Avatar.tsx
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+const Avatar = styled.img`
+  height: 30px;
+  width: 30px;
+  border-radius: 5px;
+  margin: 0 15px 0 10px;
+`;
+
+export default Avatar;

--- a/client/src/style/Text.tsx
+++ b/client/src/style/Text.tsx
@@ -1,18 +1,18 @@
 import styled from "styled-components";
 
 interface IText {
-  color: string;
-  fontSize: string;
-  fontWeight: string;
+  color?: string;
+  fontSize?: string;
+  fontWeight?: string;
   lineHeight?: string;
   isClick?: boolean;
 }
 
 const Text = styled.span<IText>`
   display: inline-block;
-  color: ${({ theme, color }) => theme.light[color] || theme.light.black};
-  font-size: ${({ theme, fontSize }) => theme.fontSizes[fontSize] || theme.fontSizes.md};
-  font-weight: ${({ theme, fontWeight }) => theme.fontWeights[fontWeight] || theme.fontWeights.regular};
+  color: ${({ theme, color }) => (color && theme.light[color]) || theme.light.black};
+  font-size: ${({ theme, fontSize }) => (fontSize && (theme.fontSizes[fontSize] || fontSize)) || theme.fontSizes.md};
+  font-weight: ${({ theme, fontWeight }) => (fontWeight && theme.fontWeights[fontWeight]) || theme.fontWeights.regular};
   line-height: ${({ lineHeight }) => lineHeight};
   cursor: ${({ isClick }) => (isClick ? "pointer" : "default")};
 `;

--- a/client/src/views/MainPage/Description/Description.tsx
+++ b/client/src/views/MainPage/Description/Description.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import styled, { keyframes } from "styled-components";
+
+import Text from "@Style/Text";
+import Button from "@Style/Button";
+
+const Description = () => {
+  return (
+    <>
+      <Wrapper>
+        <AnimWrapper />
+        <Phrase fontSize="xxl" fontWeight="extraBold">
+          지금 시작하여 퀴즈로
+          <br />
+          쉽게 공부해 보세요.
+        </Phrase>
+        <ButtonWrapper>
+          <Button>지금 바로 퀴즈 풀기</Button>
+          <Button>로그인하고 퀴즈 만들기</Button>
+        </ButtonWrapper>
+        <Text fontWeight="semiBold">로그인 후 퀴즈를 풀면 풀이 기록을 남길 수 있습니다. :)</Text>
+      </Wrapper>
+    </>
+  );
+};
+
+const Wrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  padding-bottom: 40px;
+`;
+
+const topToBottom = keyframes`
+  0% { content: "QUIZ EAZY"; }
+  50% { color: white; }
+  100% { content: "QUIZY"; }
+`;
+
+const AnimWrapper = styled.div`
+  width: 100%;
+  text-indent: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 30vh;
+  margin-top: 40px;
+  &:after {
+    animation: ${topToBottom} 3s linear infinite alternate;
+    font-size: 5rem;
+    font-weight: 800;
+    content: "QUIZ EAZY";
+    color: ${({ theme }) => theme.mode.gray4};
+    text-align: center;
+  }
+`;
+
+const Phrase = styled(Text)`
+  text-align: center;
+`;
+
+const ButtonWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin: 2rem 0;
+  ${Button}:first-child {
+    margin-right: 0.5rem;
+  }
+`;
+
+export default Description;

--- a/client/src/views/MainPage/Description/Description.tsx
+++ b/client/src/views/MainPage/Description/Description.tsx
@@ -4,21 +4,27 @@ import styled, { keyframes } from "styled-components";
 import Text from "@Style/Text";
 import Button from "@Style/Button";
 
-const Description = () => {
+interface IDescription {
+  isUser?: boolean;
+}
+
+const Description = ({ isUser }: IDescription) => {
   return (
     <>
       <Wrapper>
         <AnimWrapper />
-        <Phrase fontSize="xxl" fontWeight="extraBold">
-          지금 시작하여 퀴즈로
-          <br />
-          쉽게 공부해 보세요.
-        </Phrase>
+        {!isUser && (
+          <Phrase fontSize="xxl" fontWeight="extraBold">
+            지금 시작하여 퀴즈로
+            <br />
+            쉽게 공부해 보세요.
+          </Phrase>
+        )}
         <ButtonWrapper>
-          <Button>지금 바로 퀴즈 풀기</Button>
-          <Button>로그인하고 퀴즈 만들기</Button>
+          <Button>{isUser ? "문제 풀러 가기" : "지금 바로 퀴즈 풀기"}</Button>
+          <Button>{isUser ? "문제 만들러 가기" : "로그인하고 퀴즈 만들기"}</Button>
         </ButtonWrapper>
-        <Text fontWeight="semiBold">로그인 후 퀴즈를 풀면 풀이 기록을 남길 수 있습니다. :)</Text>
+        <Text fontWeight="semiBold">{!isUser && "로그인 후 퀴즈를 풀면 풀이 기록을 남길 수 있습니다. :)"}</Text>
       </Wrapper>
     </>
   );

--- a/client/src/views/MainPage/MainPage.tsx
+++ b/client/src/views/MainPage/MainPage.tsx
@@ -1,11 +1,27 @@
 import React from "react";
+import styled, { keyframes } from "styled-components";
 
 import Header from "@Header/Header";
+import Text from "@Style/Text";
+import Button from "@Style/Button";
 
 const MainPage = () => {
   return (
     <>
-      <Header type="none" />
+      <Header type="user" />
+      <Description>
+        <AnimWrapper />
+        <Phrase fontSize="xxl" fontWeight="extraBold">
+          지금 시작하여 퀴즈로
+          <br />
+          쉽게 공부해 보세요.
+        </Phrase>
+        <ButtonWrapper>
+          <Button>지금 바로 퀴즈 풀기</Button>
+          <Button>로그인하고 퀴즈 만들기</Button>
+        </ButtonWrapper>
+        <Text fontWeight="semiBold">로그인 후 퀴즈를 풀면 풀이 기록을 남길 수 있습니다. :)</Text>
+      </Description>
     </>
   );
 };

--- a/client/src/views/MainPage/MainPage.tsx
+++ b/client/src/views/MainPage/MainPage.tsx
@@ -26,4 +26,33 @@ const MainPage = () => {
   );
 };
 
+const Description = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+`;
+
+const AnimWrapper = styled.div`
+  width: 100%;
+  text-indent: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 30vh;
+const Phrase = styled(Text)`
+  text-align: center;
+`;
+
+const ButtonWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin: 2rem 0;
+  ${Button}:first-child {
+    margin-right: 0.5rem;
+  }
+`;
+
 export default MainPage;

--- a/client/src/views/MainPage/MainPage.tsx
+++ b/client/src/views/MainPage/MainPage.tsx
@@ -7,7 +7,7 @@ const MainPage = () => {
   return (
     <>
       <Header type="user" />
-      <Description />
+      <Description isUser={false} />
     </>
   );
 };

--- a/client/src/views/MainPage/MainPage.tsx
+++ b/client/src/views/MainPage/MainPage.tsx
@@ -33,6 +33,12 @@ const Description = styled.div`
   flex-wrap: wrap;
 `;
 
+const topToBottom = keyframes`
+  0% { content: "QUIZ EAZY"; }
+  50% { color: white; }
+  100% { content: "QUIZY"; }
+`;
+
 const AnimWrapper = styled.div`
   width: 100%;
   text-indent: 8px;
@@ -40,6 +46,16 @@ const AnimWrapper = styled.div`
   align-items: center;
   justify-content: center;
   min-height: 30vh;
+  &:after {
+    animation: ${topToBottom} 3s linear infinite alternate;
+    font-size: 5rem;
+    font-weight: 800;
+    content: "QUIZ EAZY";
+    color: ${({ theme }) => theme.light.gray4};
+    text-align: center;
+  }
+`;
+
 const Phrase = styled(Text)`
   text-align: center;
 `;

--- a/client/src/views/MainPage/MainPage.tsx
+++ b/client/src/views/MainPage/MainPage.tsx
@@ -1,74 +1,15 @@
 import React from "react";
-import styled, { keyframes } from "styled-components";
 
 import Header from "@Header/Header";
-import Text from "@Style/Text";
-import Button from "@Style/Button";
+import Description from "@MainPage/Description/Description";
 
 const MainPage = () => {
   return (
     <>
       <Header type="user" />
-      <Description>
-        <AnimWrapper />
-        <Phrase fontSize="xxl" fontWeight="extraBold">
-          지금 시작하여 퀴즈로
-          <br />
-          쉽게 공부해 보세요.
-        </Phrase>
-        <ButtonWrapper>
-          <Button>지금 바로 퀴즈 풀기</Button>
-          <Button>로그인하고 퀴즈 만들기</Button>
-        </ButtonWrapper>
-        <Text fontWeight="semiBold">로그인 후 퀴즈를 풀면 풀이 기록을 남길 수 있습니다. :)</Text>
-      </Description>
+      <Description />
     </>
   );
 };
-
-const Description = styled.div`
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
-`;
-
-const topToBottom = keyframes`
-  0% { content: "QUIZ EAZY"; }
-  50% { color: white; }
-  100% { content: "QUIZY"; }
-`;
-
-const AnimWrapper = styled.div`
-  width: 100%;
-  text-indent: 8px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 30vh;
-  &:after {
-    animation: ${topToBottom} 3s linear infinite alternate;
-    font-size: 5rem;
-    font-weight: 800;
-    content: "QUIZ EAZY";
-    color: ${({ theme }) => theme.light.gray4};
-    text-align: center;
-  }
-`;
-
-const Phrase = styled(Text)`
-  text-align: center;
-`;
-
-const ButtonWrapper = styled.div`
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
-  margin: 2rem 0;
-  ${Button}:first-child {
-    margin-right: 0.5rem;
-  }
-`;
 
 export default MainPage;


### PR DESCRIPTION
Close #14 

## 설명

### 새로운 기능

- 메인 페이지 상단 부분 마크업
- 로그인 전후를 props로 전달하여 구분하여 마크업(상태관리는 추후 로그인 기능 구현 후 구체화 예정
- 메인 부분에 글자가 바뀌는 애니메이션 추가

#### 로그인 전
<img width="876" alt="Screen Shot 2020-08-13 at 15 15 35" src="https://user-images.githubusercontent.com/30427711/90100515-d86b9f80-dd77-11ea-86f1-22fe210e36ff.png">  

#### 로그인 후
<img width="872" alt="Screen Shot 2020-08-13 at 15 16 00" src="https://user-images.githubusercontent.com/30427711/90100543-e6b9bb80-dd77-11ea-8495-f6c3f3875608.png">  



## 작업 유형

- [x] 신규 기능 추가

## 체크리스트

- [x] 이 PR의 코드들이 이 프로젝트의 스타일 가이드를 준수했는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 이해하기 힘든 부분의 코드에 주석이 작성되었는가?
- [x] 변경사항에 대한 문서를 작성하였는가?
- [x] 변경사항이 새로운 경고를 만들어내지 않았는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
